### PR TITLE
README updated about delimiter "\(...\)" and added support to run from command line through "python -m"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ There is very limited support for macros. All macros must be defined with `\def`
 Several theorem-like numbered environments are supported,
 such as `theorem`, `lemma`, `proposition`, `conjecture`, `remark`, `corollary`, `example`, and `exercise`. In addition, there is the `proof` environment.
 
-You can use the inline math environment `$...$` and the displayed math environments `$$...$$`, `\[...\]`, `\begin{equation}...\end{equation}`. WordPress has some limitations to the kind of latex equations it can display. As a consequence, `align` and `eqnarray` are not supported. You can, however, use `eqnarray*`, and you can use `array` inside a math environment.
+You can use the inline math environment `$...$`, `\(...\)` and the displayed math environments `$$...$$`, `\[...\]`, `\begin{equation}...\end{equation}`. WordPress has some limitations to the kind of latex equations it can display. As a consequence, `align` and `eqnarray` are not supported. You can, however, use `eqnarray*`, and you can use `array` inside a math environment.
 
 The tabular environment works.
 

--- a/latex2wp/__main__.py
+++ b/latex2wp/__main__.py
@@ -1,0 +1,2 @@
+from . import main
+main.main()


### PR DESCRIPTION
Adding `__main__.py` to provide a fallback method for invoking the script.

If for whatever reason that the user's `PATH` is not correctly configured to execute the `latex2wp` in the `bin`. (Happened to me once) Users can instead just do `python -m latex2wp main.tex` and everything should be the same.